### PR TITLE
Add support for the `like` filter in the stories client

### DIFF
--- a/src/Adliance.Storyblok/StoryblokStoriesQuery.cs
+++ b/src/Adliance.Storyblok/StoryblokStoriesQuery.cs
@@ -130,6 +130,9 @@ public class StoryblokStoriesQuery(StoryblokStoriesClient client, StoryblokOptio
                 case FilterOperation.LessThanInt:
                     operation = "lt-int";
                     break;
+                case FilterOperation.Like:
+                    operation = "like";
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -144,5 +147,6 @@ public enum FilterOperation
     In,
     NotIn,
     GreaterThanInt,
-    LessThanInt
+    LessThanInt,
+    Like
 }

--- a/test/Adliance.Storyblok.Tests/Clients/StoryblokStoriesClientTest.cs
+++ b/test/Adliance.Storyblok.Tests/Clients/StoryblokStoriesClientTest.cs
@@ -31,4 +31,18 @@ public class StoryblokStoriesClientTest
         Assert.NotNull(stories);
         Assert.InRange(stories.Count, 1, 10);
     }
+
+    [Fact]
+    public async Task Can_Load_Stories_With_Like_Filter()
+    {
+        _factory.CreateClient();
+        var client = _factory.Services.GetRequiredService<StoryblokStoriesClient>();
+
+        var stories = await client.Stories()
+            .Having("component", FilterOperation.Like, "page*")
+            .Load<StoryblokComponent>();
+
+        Assert.NotNull(stories);
+        Assert.InRange(stories.Count, 1, 10);
+    }
 }


### PR DESCRIPTION
Hello! We needed support for pattern-based filtering, so I opened this PR to add the Storyblok like query operation. Please let me know if this approach works for you!

### Description
Storyblok supports filtering content fields with the `like` operator, but this operation was not previously exposed by the stories client. This PR extends the allowed FilterOperations by `Like`, to allow like queries as in the api: [https://www.storyblok.com/docs/api/content-delivery/v2/filter-queries/operation-like](https://www.storyblok.com/docs/api/content-delivery/v2/filter-queries/operation-like)

### Changes
- Added `Like` to `FilterOperation`.
- Mapped `FilterOperation.Like` to Storyblok’s like query operator.
- Added test for the `like` query