### PR TITLE
Add option to ignore pattern at end of slug

### DIFF
--- a/src/Adliance.Storyblok/Middleware/StoryblokMiddleware.cs
+++ b/src/Adliance.Storyblok/Middleware/StoryblokMiddleware.cs
@@ -79,6 +79,14 @@ public class StoryblokMiddleware(RequestDelegate next)
             await next.Invoke(context);
             return;
         }
+        
+        if (settings.IgnoreSlugs.Any(x => x.StartsWith("*", StringComparison.OrdinalIgnoreCase) && slug.EndsWith(x.TrimStart('*').Trim('/'), StringComparison.OrdinalIgnoreCase)))
+        {
+            // don't handle this slug in the middleware, because the configuration starts with a *, which means we compare via EndsWith
+            logger.LogTrace($"Ignoring request \"{slug}\", because it's configured to be ignored (partial match).");
+            await next.Invoke(context);
+            return;
+        }
 
         StoryblokStory? story = null;
 

--- a/test/Adliance.Storyblok.Tests/Middleware/StoryblokMiddlewareIgnoredSlugsTest.cs
+++ b/test/Adliance.Storyblok.Tests/Middleware/StoryblokMiddlewareIgnoredSlugsTest.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Adliance.Storyblok.Clients;
+using Adliance.Storyblok.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Adliance.Storyblok.Tests.Middleware;
+
+public class StoryblokMiddlewareIgnoredSlugsTest
+{
+    [Theory]
+    [InlineData("/ignored-slug-exact")]
+    [InlineData("/ignored/test")]
+    [InlineData("/test.ign")]
+    public async Task RespectsIgnoredSlugs(string url)
+    {
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                Method = HttpMethods.Get,
+                Path = url
+            }
+        };
+        
+        var options = new StoryblokOptions
+        {
+            IgnoreSlugs = ["/ignored-slug-exact", "/ignored/*", "*.ign"]
+        };
+        
+        // Use unconfigured StoryblokStoryClient as it should never be called anyway.
+        // If it is called due to a bug, a null reference exception will be thrown, which fails the test.
+        var storyClient = CreateTestStoryClient();
+        
+        var nextCalled = false;
+
+        var middleware = new StoryblokMiddleware(Next);
+        
+        await middleware.Invoke(context, storyClient, new OptionsWrapper<StoryblokOptions>(options),
+            new NullLogger<StoryblokMiddleware>());
+        
+        var response = context.Response;
+        Assert.True(nextCalled);
+        Assert.Equal((int)HttpStatusCode.NotFound, response.StatusCode);
+        return;
+
+        Task Next(HttpContext ctx)
+        {
+            nextCalled = true;
+            ctx.Response.StatusCode = (int)HttpStatusCode.NotFound;
+            return Task.CompletedTask;
+        }
+    }
+
+    private StoryblokStoryClient CreateTestStoryClient()
+    {
+        var settings = new StoryblokOptions
+        {
+            ApiKeyPublic = "unused-but-needed-for-validation",
+            SupportedCultures = ["de"]
+        };
+        return new StoryblokStoryClient(new OptionsWrapper<StoryblokOptions>(settings), new MockClientFactory(), null!, null!, null!);
+    }
+    
+    private class MockClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+        {
+            return null!;
+        }
+    }
+}


### PR DESCRIPTION
In addition to ignore slugs with a start string, I added the option to ignore them at the end. This is useful to ignore file extensions like `*.php`.

@saxx FYI